### PR TITLE
Updated ctml_writer to clear global variables

### DIFF
--- a/scripts/ctml_writer.py
+++ b/scripts/ctml_writer.py
@@ -3118,6 +3118,19 @@ class Lindemann(object):
 validate()
 
 def convert(filename=None, outName=None, text=None):
+    # Clear global variables
+    global _elements, _species, _speciesnames, _phases, _reactions, \
+           _interactions, _beps, _atw, _enames
+    _elements = []
+    _species = []
+    _speciesnames = []
+    _phases = []
+    _reactions = []
+    _interactions = []
+    _beps = []
+    _atw = {}
+    _enames = {}
+
     import os
     if filename is not None:
         filename = os.path.expanduser(filename)


### PR DESCRIPTION
Hi Bharat,

When pMuTT writes OpenMKM's XML files, it uses ``ctml_writer.convert`` as shown by [the following lines](https://github.com/VlachosGroup/pMuTT/blob/c2a29159886cf021e2bcde93a2ca3bd781ee0377/pmutt/io/omkm.py#L164).

However, if a script is written to write multiple XML files, the following error occurs:
```
***** Error parsing input file *****


CH3CH2OH + PT(S) <=> CH3CH2OH(S) + PT(B)
A surface reaction may contain at most one surface phase.

Traceback (most recent call last):
  File "c:/Users/jonat/Dropbox (Personal)/UDel Documents (Dropbox)/UDel Research/C2H6_Heatmap/ethane_ODH_heatmap/gen_omkm_files.py", line 93, in <module>
    write_xml=True)
  File "c:\users\jonat\dropbox\udel documents (dropbox)\udel research\github\pmutt_development\pmutt\io\omkm.py", line 168, in write_cti
    convert(filename=filename, outName=xml_filename)
  File "c:\users\jonat\dropbox\udel documents (dropbox)\udel research\github\pmutt_development\pmutt\io\ctml_writer.py", line 3199, in convert
    write(outName)
  File "c:\users\jonat\dropbox\udel documents (dropbox)\udel research\github\pmutt_development\pmutt\io\ctml_writer.py", line 376, in write
    rx.build(r)
  File "c:\users\jonat\dropbox\udel documents (dropbox)\udel research\github\pmutt_development\pmutt\io\ctml_writer.py", line 1299, in build
    'one surface phase.')
pmutt.io.ctml_writer.CTI_Error: CH3CH2OH + PT(S) <=> CH3CH2OH(S) + PT(B)
A surface reaction may contain at most one surface phase.
```

I learned this was due to ``ctml_writer`` being imported once and global variables were not cleared when ``convert`` is called. To fix this, I suggest explicitly clearing the global variables whenever ``convert`` is called (see edits in pull request commit).