### PR TITLE
Print gas-phase reaction rates in the gas_gdot_out file

### DIFF
--- a/src/io.cpp
+++ b/src/io.cpp
@@ -471,8 +471,9 @@ void print_surface_species_hdr(ostream&out, const vector<shared_ptr<Solution>>& 
  * Utility function to print PFR state at given distance z from inlet
  */
 void print_pfr_rctr_state(double z, PFR1d* rctr, //vector<SurfPhase*> surfaces,
+                          std::shared_ptr<Solution> gas,
                           ostream& gas_mole_out, ostream& gas_mass_out, ostream& gas_sdot_out, 
-                          ostream& surf_cov_out, ostream& surf_sdot_out,
+                          ostream& gas_gdot_out, ostream& surf_cov_out, ostream& surf_sdot_out,
                           ostream& state_var_out)
 {
 
@@ -520,7 +521,12 @@ void print_pfr_rctr_state(double z, PFR1d* rctr, //vector<SurfPhase*> surfaces,
 
     rctr->getSurfaceProductionRates(work.data());
     gas_var_print(gas_sdot_out);
-    
+ 
+    if (gas->kinetics()->nReactions() > 0)
+    {
+        gas->kinetics()->getNetProductionRates(work.data());
+        gas_var_print(gas_gdot_out);
+    }
     surf_cov_out << scientific;
     if (data_format == OutputFormat::CSV) {
         surf_cov_out << z;

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -575,9 +575,11 @@ void print_0d_rctr_state_hdr(ostream& out, std::string ind0)
 
 
 void print_0d_rctr_state(double z, Reactor* rctr, vector<SurfPhase*> surfaces,
+                         std::shared_ptr<Solution> gas,
                          ostream& gas_mole_out, ostream& gas_mass_out,
-                         ostream& gas_sdot_out, ostream& surf_cov_out,
-                         ostream& surf_sdot_out, ostream& state_var_out)
+                         ostream& gas_sdot_out, ostream& gas_gdot_out, 
+                         ostream& surf_cov_out, ostream& surf_sdot_out, 
+                         ostream& state_var_out)
 {
 
     vector<double> work(rctr->contents().nSpecies());
@@ -642,6 +644,12 @@ void print_0d_rctr_state(double z, Reactor* rctr, vector<SurfPhase*> surfaces,
 
     rctr->getSurfaceProductionRates(work.data());
     gas_var_print(gas_sdot_out);
+
+    if (gas->kinetics()->nReactions() > 0)
+    {
+                gas->kinetics()->getNetProductionRates(work.data());
+        gas_var_print(gas_gdot_out);
+    }
 
     surf_cov_out << scientific;
     if (data_format == OutputFormat::CSV) {

--- a/src/io.h
+++ b/src/io.h
@@ -155,9 +155,10 @@ void print_pfr_rctr_state(double z, PFR1d* rctr,
  */
 void print_0d_rctr_state(double z, Cantera::Reactor* rctr, 
                           std::vector<Cantera::SurfPhase*> surfaces,
+                          std::shared_ptr<Cantera::Solution> gas, 
                           std::ostream& gas_mole_out, std::ostream& gas_mass_out,
-                          std::ostream& gas_msdot_out, std::ostream& surf_cov_out,
-                          std::ostream& surf_msdot_out, std::ostream& state_var_out);
+                          std::ostream& gas_msdot_out, std::ostream& gas_gdot_out, 
+                          std::ostream& surf_cov_out, std::ostream& surf_msdot_out, std::ostream& state_var_out);
 
 }
 #endif

--- a/src/io.h
+++ b/src/io.h
@@ -147,8 +147,10 @@ void print_pfr_state_hdr(std::ostream& out);
  */
 void print_pfr_rctr_state(double z, PFR1d* rctr, 
                           //std::vector<Cantera::SurfPhase*> surfaces,
+                          std::shared_ptr<Cantera::Solution> gas,
                           std::ostream& gas_mole_out, std::ostream& gas_mass_out,
-                          std::ostream& gas_sdot_out, std::ostream& surf_cov_out,
+                          std::ostream& gas_sdot_out, std::ostream& gas_gdot_out,
+                          std::ostream& surf_cov_out,
                           std::ostream& surf_sdot_out, std::ostream& state_var_out);
 /**
  * Utility function to print 0d reactor state at given distance from inlet

--- a/src/onedReactor.cpp
+++ b/src/onedReactor.cpp
@@ -262,6 +262,7 @@ void run_1d_reactor(ReactorParser& rctr_parser,
                 ofstream gas_mole_out((out_dir / ("gas_mole_ss." + file_ext)).string(), ios::out);
                 ofstream gas_mass_out((out_dir / ("gas_mass_ss." + file_ext)).string(), ios::out);
                 ofstream gas_sdot_out((out_dir / ("gas_sdot_ss." + file_ext)).string(), ios::out);
+                ofstream gas_gdot_out((out_dir / ("gas_gdot_ss." + file_ext)).string(), ios::out);
                 ofstream surf_cov_out((out_dir / ("surf_cov_ss." + file_ext)).string(), ios::out);
                 ofstream surf_sdot_out((out_dir / ("surf_sdot_ss." + file_ext)).string(), ios::out);
                 ofstream state_var_out((out_dir / ("rctr_state_ss." + file_ext)).string(), ios::out);
@@ -272,6 +273,7 @@ void run_1d_reactor(ReactorParser& rctr_parser,
                     gas_mole_out << "# Gas Mole fractions\n";
                     gas_mass_out << "# Gas Mass fractions\n";
                     gas_sdot_out << "# Surface Production Rates of  Gas Species (units of kmol/s)\n";
+                    gas_gdot_out << "# Gas Production Rates of Gas Species (units of kmol/s)\n";
                     surf_cov_out << "# Surace Coverages\n";
                     surf_sdot_out << "# Production Rates of Surface Species (units of kmol/m2/s) \n";
                     state_var_out << "# Steady State Reactor State\n";
@@ -280,6 +282,7 @@ void run_1d_reactor(ReactorParser& rctr_parser,
                 print_gas_species_hdr(gas_mole_out, gas->thermo().get(), "z(m)");
                 print_gas_species_hdr(gas_mass_out, gas->thermo().get(), "z(m)");
                 print_gas_species_hdr(gas_sdot_out, gas->thermo().get(), "z(m)");
+                print_gas_species_hdr(gas_gdot_out, gas->thermo().get(), "z(m)");
                 print_surface_species_hdr(surf_cov_out, surfaces, "z(m)");
                 print_surface_species_hdr(surf_sdot_out, surfaces, "z(m)");
                 print_pfr_state_hdr(state_var_out);
@@ -294,8 +297,9 @@ void run_1d_reactor(ReactorParser& rctr_parser,
 
                 for (const auto& z : zvals) {
                     pfr_solver.solve(z);
-                    print_pfr_rctr_state(z, &pfr, gas_mole_out, gas_mass_out, 
-                                         gas_sdot_out, surf_cov_out, surf_sdot_out, state_var_out);
+                    print_pfr_rctr_state(z, &pfr, gas, gas_mole_out, gas_mass_out, 
+                                         gas_sdot_out, gas_gdot_out, surf_cov_out, 
+                                         surf_sdot_out, state_var_out);
                     if (rpa_flag) {
                         string rpa_file_name = "rates_z-";
                         rpa_file_name += to_string(z);

--- a/src/zerodReactor.cpp
+++ b/src/zerodReactor.cpp
@@ -357,6 +357,7 @@ void run_0d_reactor(ReactorParser& rctr_parser,
                 ofstream gas_mole_ss_out ((out_dir / ("gas_mole_ss." + file_ext)).string(), ios::out);
                 ofstream gas_mass_ss_out ((out_dir / ("gas_mass_ss." + file_ext)).string(), ios::out);
                 ofstream gas_sdot_ss_out ((out_dir / ("gas_sdot_ss." + file_ext)).string(), ios::out);
+                ofstream gas_gdot_ss_out((out_dir / ("gas_gdot_ss." + file_ext)).string(), ios::out);
                 ofstream surf_cov_ss_out ((out_dir / ("surf_cov_ss." + file_ext)).string(), ios::out);
                 ofstream surf_sdot_ss_out ((out_dir / ("surf_sdot_ss." + file_ext)).string(), ios::out);
                 ofstream state_var_ss_out ((out_dir / ("rctr_state_ss." + file_ext)).string(), ios::out);
@@ -366,6 +367,7 @@ void run_0d_reactor(ReactorParser& rctr_parser,
                     gas_mole_ss_out << "# Gas Mole fractions at Steady State\n";
                     gas_mass_ss_out << "# Gas Mass fractions at Steady State\n";
                     gas_sdot_ss_out << "# Surface Production Rates of  Gas Species (units of kmol/s) at Steady State\n";
+                    gas_gdot_ss_out << "# Gas phase Production Rates of  Gas Species (units of kmol/s) at Steady State\n";
                     surf_cov_ss_out << "# Surface Coverages of Surface Species at Steady State\n"; 
                     surf_sdot_ss_out << "# Production Rates of Surface Species (units of kmol/m2/s) at Steady State\n"; 
                     state_var_ss_out << "# Steady State Reactor State\n";
@@ -422,6 +424,7 @@ void run_0d_reactor(ReactorParser& rctr_parser,
                     print_gas_species_hdr(gas_mole_ss_out, gas->thermo().get(), "z(m^3)");
                     print_gas_species_hdr(gas_mass_ss_out, gas->thermo().get(), "z(m^3)");
                     print_gas_species_hdr(gas_sdot_ss_out, gas->thermo().get(), "z(m^3)");
+                    print_gas_species_hdr(gas_gdot_ss_out, gas->thermo().get(), "z(m^3)");
                     print_surface_species_hdr(surf_cov_ss_out, surfaces, "z(m^3)");
                     print_surface_species_hdr(surf_sdot_ss_out, surfaces, "z(m^3)");
                     print_0d_rctr_state_hdr(state_var_ss_out, "z(m^3)");
@@ -429,6 +432,7 @@ void run_0d_reactor(ReactorParser& rctr_parser,
                     print_gas_species_hdr(gas_mole_ss_out, gas->thermo().get(), "t(s)");
                     print_gas_species_hdr(gas_mass_ss_out, gas->thermo().get(), "t(s)");
                     print_gas_species_hdr(gas_sdot_ss_out, gas->thermo().get(), "t(s)");
+                    print_gas_species_hdr(gas_gdot_ss_out, gas->thermo().get(), "t(s)");
                     print_surface_species_hdr(surf_cov_ss_out, surfaces, "t(s)");
                     print_surface_species_hdr(surf_sdot_ss_out, surfaces, "t(s)");
                     print_0d_rctr_state_hdr(state_var_ss_out, "t(s)");
@@ -447,9 +451,9 @@ void run_0d_reactor(ReactorParser& rctr_parser,
                     // Print the inlet state
                     //rnet.reinitialize();
                 if (rctr_type != BATCH) {
-                    print_0d_rctr_state(0, rctr.get(), surf_phases, 
+                    print_0d_rctr_state(0, rctr.get(), surf_phases, gas, 
                                         gas_mole_ss_out, gas_mass_ss_out, gas_sdot_ss_out, 
-                                        surf_cov_ss_out, surf_sdot_ss_out, 
+                                        gas_gdot_ss_out, surf_cov_ss_out, surf_sdot_ss_out,  
                                         state_var_ss_out);
                 }
 
@@ -457,6 +461,7 @@ void run_0d_reactor(ReactorParser& rctr_parser,
                 ofstream gas_mole_tr_out ((out_dir / ("gas_mole_tr." + file_ext)).string(), ios::out);
                 ofstream gas_mass_tr_out ((out_dir / ("gas_mass_tr." + file_ext)).string(), ios::out);
                 ofstream gas_sdot_tr_out ((out_dir / ("gas_sdot_tr." + file_ext)).string(), ios::out);
+                ofstream gas_gdot_tr_out((out_dir / ("gas_gdot_tr." + file_ext)).string(), ios::out);
                 ofstream surf_cov_tr_out ((out_dir / ("surf_cov_tr." + file_ext)).string(), ios::out);
                 ofstream surf_sdot_tr_out ((out_dir / ("surf_sdot_tr." + file_ext)).string(), ios::out);
                 ofstream state_var_tr_out ((out_dir / ("rctr_state_tr." + file_ext)).string(), ios::out);
@@ -465,12 +470,14 @@ void run_0d_reactor(ReactorParser& rctr_parser,
                         gas_mole_tr_out << "# Transient Gas Mole fractions"  << endl;
                         gas_mass_tr_out << "# Transient Gas Mass fractions"  << endl;
                         gas_sdot_tr_out << "# Transient Surface Production Rates of Gas Species (units of kmol/s)"  << endl;
+                        gas_gdot_tr_out << "# Transient Gas Production Rates of Gas Species (units of kmol/s)" << endl;
                         surf_cov_tr_out << "# Transient Surface Coverages of Surface Species"  << endl;
                         surf_sdot_tr_out << "# Transient Production Rates of Surface Species (units of kmol/m2/s)"  << endl;
                     }
                     print_gas_species_hdr(gas_mole_tr_out, gas->thermo().get(), "t(s)");
                     print_gas_species_hdr(gas_mass_tr_out, gas->thermo().get(), "t(s)");
                     print_gas_species_hdr(gas_sdot_tr_out, gas->thermo().get(), "t(s)");
+                    print_gas_species_hdr(gas_gdot_tr_out, gas->thermo().get(), "t(s)");
                     print_surface_species_hdr(surf_cov_tr_out, surfaces, "t(s)");
                     print_surface_species_hdr(surf_sdot_tr_out, surfaces, "t(s)");
                     print_0d_rctr_state_hdr(state_var_tr_out, "t(s)");
@@ -503,8 +510,8 @@ void run_0d_reactor(ReactorParser& rctr_parser,
                         for (const auto & tm : times) {
                             rnet.advance(tm);
                             if (transient_log) {
-                                print_0d_rctr_state(tm, rctr.get(), surf_phases, 
-                                                    gas_mole_tr_out, gas_mass_tr_out, gas_sdot_tr_out, 
+                                print_0d_rctr_state(tm, rctr.get(), surf_phases, gas, 
+                                                    gas_mole_tr_out, gas_mass_tr_out, gas_sdot_tr_out, gas_gdot_tr_out,
                                                     surf_cov_tr_out, surf_sdot_tr_out, 
                                                     state_var_tr_out);
 
@@ -521,9 +528,9 @@ void run_0d_reactor(ReactorParser& rctr_parser,
                         ind_val = times.back();
                     }
                         
-                    print_0d_rctr_state(ind_val, rctr.get(), surf_phases, 
+                    print_0d_rctr_state(ind_val, rctr.get(), surf_phases, gas, 
                                         gas_mole_ss_out, gas_mass_ss_out, gas_sdot_ss_out, 
-                                        surf_cov_ss_out, surf_sdot_ss_out, 
+                                        gas_gdot_ss_out, surf_cov_ss_out, surf_sdot_ss_out, 
                                         state_var_ss_out);
 
                     if (rpa_flag) {


### PR DESCRIPTION
This pull request Fixes #54  

Updating OpenMKM IO to print net production rates for gas-species for reactions occuring in the gas-phase in the gas_gdot_out file. 